### PR TITLE
chore: upgrades version of checkstyle tool to 10.23.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ java {
 }
 
 checkstyle {
+    // fix CVE-2023-2976
+    toolVersion = "10.23.1"
     configDirectory = file("$rootProject.projectDir/checkstyle")
     configProperties = [
             "org.checkstyle.google.suppressionfilter.config":


### PR DESCRIPTION
- upgrades version of checkstyle tool to 10.23.1 to fix security issue CVE-2023-2976